### PR TITLE
Dart MCP サーバーを登録し、UIレビュー手順の更新とルーティング不具合の修正を行います

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "dart": {
+      "command": "dart",
+      "args": ["mcp-server"]
+    }
+  }
+}

--- a/docs/notes/ai-ui-review.md
+++ b/docs/notes/ai-ui-review.md
@@ -1,6 +1,6 @@
 # AI による UI レビューのための情報取得方法 — 調査ノート
 
-調査日: 2026-07-08
+調査日: 2026-07-08 / 実地検証にもとづく改訂: 2026-08-02
 
 AI (Claude Code 等) にアプリの UI をレビューさせるために、
 UI 階層構造やスクリーンショットを取得する方法の調査結果をまとめる。
@@ -8,34 +8,24 @@ UI 階層構造やスクリーンショットを取得する方法の調査結�
 ## 結論
 
 **Dart SDK 3.12 に同梱されている公式の Dart/Flutter MCP サーバー (`dart mcp-server`) を
-Claude Code に登録する方法が最適。**
-追加パッケージなし・アプリコードの変更なしで、実行中アプリへの接続、
-ウィジェットツリー取得、スクリーンショット取得、画面操作までできる。
+Claude Code に登録する。** 追加パッケージなし・アプリコードの変更なしで、
+実行中アプリへの接続、ウィジェットツリー取得、実行時エラー取得、hot reload まで行える。
 
-## 公式 Dart MCP サーバーで確認できた機能
+ただし**レビュー対象は Web (`flutter run`) とする**。初版は macOS デスクトップを前提に
+していたが、本リポジトリに macOS デスクトップ対応は入っていない (下記の訂正を参照)。
 
-ローカルで `dart mcp-server` を起動し、JSON-RPC 経由でツール一覧を取得して確認済み
-(Flutter 3.44.4 / Dart 3.12.2)。UI レビューに直結するツールは以下:
+## 初版の誤りと訂正 (2026-08-02 実地検証)
 
-| ツール | できること |
+| 初版の記述 | 実際 |
 |---|---|
-| `dtd` | Dart Tooling Daemon 経由で実行中アプリに接続する。`listDtdUris` → `connect` の順で使う |
-| `widget_inspector` | ウィジェットツリー取得 (`get_widget_tree`)。`summaryOnly: true` でユーザーコード由来の widget のみに絞れる |
-| `flutter_driver_command` | **`screenshot`** によるスクリーンショット取得。`tap` / `enter_text` / `scroll` / `waitFor` 等で AI が画面を操作して遷移できる |
-| `get_runtime_errors` | RenderFlex overflow などの実行時レイアウトエラー取得 |
-| `hot_reload` / `hot_restart` | 修正 → 即反映 → 再スクリーンショットのループが回せる |
+| 「本アプリはデスクトップ対応なので問題ない」 | **`macos/` ディレクトリが存在せず、macOS デスクトップは未対応。** git 管理下のプラットフォームは `android` / `ios` / `web` のみ。`mise run` も `flutter run --web-port=50505` で、実運用ターゲットは Web (GitHub Pages) |
+| `flutter run -d macos --print-dtd` で DTD URI を表示させる | **Flutter 3.44.4 の `flutter run` に `--print-dtd` は存在しない** (`flutter run --help` に該当オプションなし) |
+| (記載なし) | **`.mcp.json` を追加しても実行中の Claude Code セッションには反映されない。** MCP サーバーはセッション起動時に読み込まれるため、登録後にセッションを開き直す必要がある |
+| (記載なし) | **`dart mcp-server` 自身がアプリを起動・管理できる** (`launch_app` / `list_running_apps` / `stop_app`)。DTD URI を人間が手で渡す前提の手順は必須ではない |
 
-これにより「起動中のアプリに接続 → 画面を操作しながらスクリーンショットと
-階層構造を取得 → レビュー → 修正 → hot reload → 再確認」というループが実現できる。
+## セットアップ
 
-## セットアップ手順
-
-```bash
-# Claude Code に登録 (プロジェクト共有なら .mcp.json に書く)
-claude mcp add dart -- dart mcp-server
-```
-
-`.mcp.json` に書く場合:
+リポジトリ直下の `.mcp.json` で登録済み (プロジェクト共有):
 
 ```json
 {
@@ -48,25 +38,92 @@ claude mcp add dart -- dart mcp-server
 }
 ```
 
-### 利用時の流れ
+個人環境だけに入れる場合は `claude mcp add dart -- dart mcp-server`。
 
-1. `flutter run -d macos --print-dtd` でアプリを起動 (DTD URI が表示される)
-2. Claude に「DTD `<uri>` に接続して UI をレビューして」と依頼
-3. `dtd` ツールで接続後、上記の各ツールが使えるようになる
+**登録後は Claude Code のセッションを開き直すこと。** 既存セッションには反映されない。
 
-## 注意点
+## Dart MCP サーバーの機能一覧
 
-- **macOS デスクトップで実行するのが前提。**
-  Flutter Web は canvas 描画のため VM service 経由のスクリーンショットが使えず、
-  Playwright 等でページを撮っても DOM から UI 階層は取れない。
-  本アプリはデスクトップ対応なので問題ない。
-- `flutter_driver_command screenshot` が macOS デスクトップで確実に動くかは
-  実際にアプリを起動しての実地確認が未了 (ツールの存在は確認済み)。
-  動かない場合のフォールバックとして、macOS 標準の `screencapture -l <windowID>` で
-  アプリウィンドウだけを撮るスクリプトを用意する手がある
-  (ウィンドウ ID は `GetWindowID` や AppleScript で取得可能)。
+`dart mcp-server --help` の `--enable` / `--disable` 候補として列挙される
+(Flutter 3.44.4 / Dart 3.12.2 で確認):
+
+```
+analyze_files, create_project, dart_fix, dart_format, dtd, flutter_driver_command,
+get_active_location, get_app_logs, get_runtime_errors, hot_reload, hot_restart,
+launch_app, list_devices, list_running_apps, lsp, pub, pub_dev_search,
+read_package_uris, rip_grep_packages, roots, run_tests, stop_app, widget_inspector,
+flutter_driver_user_journey_test
+```
+
+UI レビューに直結するもの:
+
+| ツール | できること |
+|---|---|
+| `launch_app` / `list_running_apps` / `stop_app` | MCP サーバー自身がアプリを起動・列挙・停止する |
+| `dtd` | Dart Tooling Daemon 経由で実行中アプリに接続する (`listDtdUris` → `connect`) |
+| `widget_inspector` | ウィジェットツリー取得 (`get_widget_tree`)。`summaryOnly: true` でユーザーコード由来の widget のみに絞れる |
+| `get_runtime_errors` | RenderFlex overflow などの実行時レイアウトエラー取得 |
+| `get_app_logs` | アプリログ取得 |
+| `hot_reload` / `hot_restart` | 修正 → 即反映 → 再確認のループが回せる |
+| `flutter_driver_command` | `tap` / `enter_text` / `scroll` / `waitFor` / `screenshot`。ただし Web での可否は未確認 (下記) |
+
+## Web でのレビュー手順
+
+```bash
+mise run setup                                   # 依存解決 (worktree では毎回必要)
+flutter run -d web-server --web-port=50505       # http://localhost:50505 で配信
+```
+
+- 生成コード (`*.g.dart` / `*.freezed.dart`) は git 管理下なので `build_runner` は不要。
+- ログインは **匿名サインイン**が使えるため、Google OAuth を通さずにレビューできる
+  (`lib/feature/auth/view/sign_in_button.dart` の "Sign in anonymously")。
+- ポートを 50505 に固定するのは Firebase Auth のログイン状態を origin 単位で維持するため。
+  レビュー時もこのポートを保つこと。
+
+### `-d chrome` と `-d web-server` の違い
+
+- `-d chrome`: Flutter が専用プロファイルの Chrome を新規に起動する。
+  そのウィンドウには Claude の Chrome 拡張が入っていないため、拡張経由の操作はできない。
+- `-d web-server`: HTTP 配信のみ。任意の Chrome で開けるので拡張経由の操作と組み合わせられる。
+  ただし起動時に「デバッグには Dart Debug Chrome 拡張が必要」と警告が出る。
+
+## ブラウザ操作側 (claude-in-chrome) の注意
+
+- **claude-in-chrome は「実行マシン」ではなく「アカウント」単位で Chrome 拡張に接続する。**
+  Anthropic 側のリレー経由で繋がるため、拡張が入っている Chrome は別マシンのものでも
+  `list_connected_browsers` に出てくる。`isLocal` フィールドで同一マシンかを判定できる。
+- 接続先の Chrome が別マシンだと、その Chrome の `localhost:50505` は
+  **そのマシン自身の** localhost を指すため `ERR_CONNECTION_REFUSED` になる。
+- 対処は **SSH ポートフォワード**。ブラウザ側のマシンから:
+
+  ```
+  ssh -N -L 50505:127.0.0.1:50505 <user>@<flutter run しているホスト>
+  ```
+
+  既存の SSH セッションがあるなら、エスケープシーケンスで後付けもできる
+  (`Enter` → `~C` → `ssh> -L 50505:127.0.0.1:50505`)。
+- LAN の IP で直接開く方法もあるが、オリジンが `localhost:50505` から変わってしまい
+  Firebase Auth のログイン状態の維持やドメイン制約に影響するため、
+  ポートフォワードでオリジンを保つほうがよい。
+
+## 未確認事項
+
+- `widget_inspector` の `get_widget_tree` が Web (dwds) 経由で機能するか。
+  `-d web-server` は VM service デバッグに Dart Debug Chrome 拡張を要求する旨の
+  警告を出すため、拡張なしでは繋がらない可能性がある。
+- `flutter_driver_command` の `screenshot` が Web で使えるか。
+  使えない場合は Chrome 拡張側の screenshot で代替する
+  (CanvasKit 描画でも画面のピクセルは取得できるので視覚レビューには支障ない)。
+- Flutter Web はセマンティクスを有効化すると DOM にアクセシビリティツリーを構築するため、
+  ウィジェット階層の代替として利用できる可能性がある (未検証)。
 
 ## 検討した代替案 (非推奨)
+
+### macOS デスクトップ対応を追加する
+
+`flutter create --platforms=macos .` で `macos/` 一式を追加すれば初版の想定どおりになるが、
+Firebase の macOS 設定やネットワーク entitlement の整備が必要で差分が大きい。
+実運用ターゲットが Web である以上、レビュー環境としても Web のほうが実機に近い。
 
 ### integration_test + ゴールデンテスト
 

--- a/docs/notes/ai-ui-review.md
+++ b/docs/notes/ai-ui-review.md
@@ -106,16 +106,46 @@ flutter run -d web-server --web-port=50505       # http://localhost:50505 で配
   Firebase Auth のログイン状態の維持やドメイン制約に影響するため、
   ポートフォワードでオリジンを保つほうがよい。
 
-## 未確認事項
+## UI 階層の取得: セマンティクスを有効化する (実証済み)
 
-- `widget_inspector` の `get_widget_tree` が Web (dwds) 経由で機能するか。
-  `-d web-server` は VM service デバッグに Dart Debug Chrome 拡張を要求する旨の
-  警告を出すため、拡張なしでは繋がらない可能性がある。
-- `flutter_driver_command` の `screenshot` が Web で使えるか。
-  使えない場合は Chrome 拡張側の screenshot で代替する
-  (CanvasKit 描画でも画面のピクセルは取得できるので視覚レビューには支障ない)。
-- Flutter Web はセマンティクスを有効化すると DOM にアクセシビリティツリーを構築するため、
-  ウィジェット階層の代替として利用できる可能性がある (未検証)。
+**Dart MCP の `widget_inspector` を使わなくても、Flutter Web のセマンティクスを
+有効化すれば UI 階層が DOM のアクセシビリティツリーとして取れる。**
+
+CanvasKit 描画のため初期状態では DOM に中身がないが、Flutter Web は
+`<flt-semantics-placeholder>` という隠しボタンを持っており、これをクリックすると
+セマンティクスが有効になりアクセシビリティツリーが構築される。
+
+```js
+document.querySelector('flt-semantics-placeholder').click()
+```
+
+有効化後にアクセシビリティツリーを読むと、実際に以下が取れた:
+
+```
+heading "漫画を選択"
+button "新規作成"
+group "無名の傑作 ページ数: 3"
+  button                      ← ラベルなし (tooltip / semanticsLabel 未設定)
+```
+
+この方法の利点:
+
+- ロール (`heading` / `button` / `group`) とラベルが取れるので、**構造レビューと
+  アクセシビリティレビューを同時にできる**。ラベルのないボタンがそのまま名前なしで出る。
+- Dart Debug Chrome 拡張も VM service 接続も不要。ブラウザ側だけで完結する。
+- 一度有効化するとページ遷移後も維持される。
+
+## 実地検証で分かった制約
+
+- **ホイールスクロールがアプリに届かない。** Chrome 拡張から合成したスクロールイベントは
+  CanvasKit のリスナに拾われず、スクロール可能な領域を動かせなかった。
+  画面外の要素を確認したいときは、ウィンドウをリサイズするか、
+  アプリ内のナビゲーション (一覧画面など) を経由する。
+- **`flutter_driver_command` の `screenshot` は Web では期待しないほうがよい。**
+  スクリーンショットは Chrome 拡張側で撮れば十分 (CanvasKit 描画でもピクセルは取得できる)。
+- デバッグビルドの **DEBUG バナーが右上を覆う**ため、AppBar の右端にあるアクションが
+  隠れて見えない。ホバーすると tooltip が出るので存在は確認できる。
+  リリースビルドでは問題にならない。
 
 ## 検討した代替案 (非推奨)
 

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -28,7 +28,7 @@ GoRouter router(Ref ref) {
   ref.onDispose(updateNotifier.dispose);
 
   return GoRouter(
-    initialLocation: '/',
+    initialLocation: '/manga',
     refreshListenable: Listenable.merge([authNotifier, updateNotifier]),
     redirect: (context, state) {
       // バージョンゲートを最優先で評価する。
@@ -37,7 +37,7 @@ GoRouter router(Ref ref) {
       if (needsUpdate) {
         return isUpdateRoute ? null : '/update-required';
       }
-      if (isUpdateRoute) return '/';
+      if (isUpdateRoute) return '/manga';
 
       final authState = ref.read(authStateStreamProvider);
       if (authState.isLoading) return null;
@@ -50,6 +50,11 @@ GoRouter router(Ref ref) {
       return null;
     },
     routes: [
+      // MangaSelectPage は /manga に移動したため、旧 URL とブックマークを転送する。
+      GoRoute(
+        path: '/',
+        redirect: (context, state) => '/manga',
+      ),
       GoRoute(
         path: '/update-required',
         builder: (context, state) => const UpdateRequiredPage(),


### PR DESCRIPTION
## 概要

Dart/Flutter MCP サーバーをプロジェクトに登録し、`docs/notes/ai-ui-review.md` の調査ノートを実機検証の結果で更新します。
あわせて、その UI レビューで見つかったルーティングのリグレッションを修正します。

## 1. `fix(router)` — ルート URL で Page Not Found になる問題

**未リリースのリグレッションです（`main` では発生しません）。**

`b39f617` で MangaSelectPage のパスを `/` から `/manga` に変更した際、`initialLocation: '/'` が追従していませんでした。

ログイン済みユーザーが `/` を開くと `redirect` がどの分岐にも当たらず `null` を返すため、`/` が未マッチのまま `GoException: no route for location: /` で固定されます。`refreshListenable` で再評価されても回復しません。未ログイン時は `/login` に飛ぶため表面化しません。

さらに `3fbacc6` で追加された `if (isUpdateRoute) return '/';` も同じ行き止まりを踏んでいました。

**変更点**
- `initialLocation` を `/manga` に変更
- 更新ゲート解除後の遷移先 `'/'` も `/manga` に統一
- 旧 URL とブックマーク救済のため `/` → `/manga` のリダイレクトルートを追加

**検証**: `flutter run -d web-server --web-port=50505` でログイン済みの状態から `/` を開き、`#/manga` に転送されて漫画選択画面が表示されることを確認。`flutter analyze` / `flutter test` ともに通過（27 tests passed）。

## 2. `.mcp.json`（新規）

Dart SDK 3.12 同梱の `dart mcp-server` をプロジェクト共有の MCP サーバーとして登録します。
**登録後は Claude Code のセッションを開き直す必要があります**（MCP サーバーはセッション起動時に読み込まれるため）。

## 3. `docs/notes/ai-ui-review.md`

初版の前提に誤りがあったため訂正し、実証済みの手順に差し替えます。

**訂正した誤り**
- 「本アプリはデスクトップ対応」→ `macos/` は存在せず macOS デスクトップは未対応。レビュー対象を Web に変更
- `flutter run --print-dtd` → Flutter 3.44.4 に該当オプションは存在しない
- `.mcp.json` はセッション起動時に読み込まれる点を追記

**新たに実証した手順**

`flt-semantics-placeholder` をクリックして Flutter Web のセマンティクスを有効化すると、UI 階層がアクセシビリティツリーとして取得できます。`widget_inspector` も VM service 接続も不要です。

```js
document.querySelector('flt-semantics-placeholder').click()
```

ロールとラベルが取れるため、構造レビューとアクセシビリティレビューを同時に行えます。

## 本 PR に含めていない指摘

UI レビューで挙がった以下は `main` にも存在する既存の問題のため、別途対応とします。

- `MaterialApp` に `supportedLocales` がなく Material / flutter_quill の文言が英語のまま
- `manga_grid_page.dart` の `Text('Page $pageNumber')` が英語ハードコード
- アイコンボタン（削除・エクスポート・複製など）に tooltip / semanticsLabel がない
- 編集画面左ペインの左端不揃い、AppBar のタイトルと戻る矢印の縦ずれ 等

🤖 Generated with [Claude Code](https://claude.com/claude-code)