### PR TITLE
リリース前チェックの修正と CI・リリース workflow の整備

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -11,16 +11,28 @@ GitHub Actions で Flutter Web を GitHub Pages にデプロイする。
 
 ## Workflow
 
-- ファイル: `.github/workflows/main.yml`
-- トリガー: `main` ブランチへの push、または手動実行 (`workflow_dispatch`)
-- 処理: `flutter build web --release` → GitHub Pages アーティファクトとしてデプロイ
+| ファイル | トリガー | 処理 |
+|---|---|---|
+| `ci.yml` | PR / `develop` への push / 手動 | 両パッケージの `flutter analyze`・`flutter test` と、デプロイと同条件の Web ビルド |
+| `main.yml` | `main` への push / 手動 (`workflow_dispatch`) | `flutter build web --release --dart-define=ENV=prod` → GitHub Pages へデプロイ → 公開ページの疎通確認 |
+| `release.yml` | `v*` タグの push | GitHub Release を作成（リリース後に手で行う作業のチェックリスト付き） |
+
 - バージョン管理: `mise` で Flutter / Dart のバージョンを固定
+- `main.yml` の `workflow_dispatch` はロールバックの実行口も兼ねる
+  （`mise run rollback-web <tag>` が過去タグの ref で起動する）
 
 ## 変更時の注意
 
 - 環境変数を扱う場合は `--dart-define` 経由で渡す（`ENV` など）
-- Firebase の prod / dev 切り替えは `ENV` で行う（[lib/env_config.dart](../../lib/env_config.dart)）
+- Firebase の prod / dev 切り替えは `ENV` で行う（[lib/env_config.dart](../../lib/env_config.dart)）。
+  **Web デプロイのビルドには `--dart-define=ENV=prod` が必須**（未指定だと dev Firebase に繋がる）
 - デプロイ先 URL の base-href は `--base-href` で指定される点に注意
+- `mise-action` には `install_args: flutter` を指定する。`mise.toml` には `ruby` / `node` も
+  含まれるが CI では不要で、特に `ruby` はソースビルドになり CI 時間を大きく浪費する
+- `flutter analyze` / `flutter test` は**カレントパッケージしか対象にしない**。
+  `local_package/my_manga_editor_data` は個別に実行する
+  （`ci.yml` と [scripts/release.sh](../../scripts/release.sh) の双方で対応済み。
+  ローカルでは `mise run check`）
 
 ## リリース時のバージョン運用
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+# リリース (main への push) の前に develop / PR で品質ゲートを通すための workflow。
+# 実施内容は scripts/release.sh の品質ゲートと揃えてある。
+on:
+  pull_request:
+  push:
+    branches: [ "develop" ]
+  workflow_dispatch:
+
+# 同じ ref に新しい push が来たら古い実行は打ち切る
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze_test:
+    name: Analyze & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+        with:
+          # mise.toml には ruby / node も含まれるが解析・テストには不要。
+          # 特に ruby はソースビルドになり CI が大幅に遅くなるため入れない。
+          install_args: flutter
+
+      - name: Install dependencies (root)
+        run: flutter pub get
+
+      - name: Install dependencies (my_manga_editor_data)
+        run: flutter pub get
+        working-directory: local_package/my_manga_editor_data
+
+      - name: Analyze (root)
+        run: flutter analyze
+
+      # flutter analyze はカレントパッケージのみが対象なのでデータ層は個別に流す
+      - name: Analyze (my_manga_editor_data)
+        run: flutter analyze
+        working-directory: local_package/my_manga_editor_data
+
+      - name: Test (root)
+        run: flutter test
+
+      # flutter test も同様。ルートの flutter test には含まれない
+      - name: Test (my_manga_editor_data)
+        run: flutter test
+        working-directory: local_package/my_manga_editor_data
+
+  build_web:
+    name: Build Web (prod)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+        with:
+          install_args: flutter
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Setup base-href
+        id: base-href
+        run: |
+          REPOSITORY=$(echo ${{ github.repository }} | sed -e "s#.*/##")
+          echo "repository=$REPOSITORY" >> $GITHUB_OUTPUT
+
+      # デプロイ (main.yml) と同じ条件でビルドし、main へマージしてから
+      # 初めてビルドが壊れていると分かる事態を防ぐ
+      - name: Build Flutter Web
+        run: flutter build web --release --dart-define=ENV=prod --base-href /${{ steps.base-href.outputs.repository }}/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Build & Deploy Flutter Web to GitHub Pages
 
+# main への push で本番 (GitHub Pages + prod Firebase) へデプロイする。
+# workflow_dispatch はロールバック用 (`mise run rollback-web <tag>` が過去タグ ref で起動する)。
 on:
   push:
     branches: [ "main" ]
@@ -10,15 +12,29 @@ permissions:
   pages: write
   id-token: write
 
+# Pages へのデプロイは同時に 1 つだけ。実行中のデプロイは中断しない
+# (途中で止めると公開物が中途半端な状態になるため cancel-in-progress: false)
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build_deploy:
     runs-on: ubuntu-latest
 
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup mise
-        uses: jdx/mise-action@v2.0.2
+        uses: jdx/mise-action@v2
+        with:
+          # mise.toml には ruby / node も含まれるが Web ビルドには不要。
+          # 特に ruby はソースビルドになり CI が大幅に遅くなるため入れない。
+          install_args: flutter
       - name: Install dependencies
         run: flutter pub get
       - name: Setup base-href
@@ -36,3 +52,21 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      # デプロイ直後は CDN 反映に数十秒かかることがあるためリトライしながら確認する。
+      # 「Actions は緑なのに本番が 404」を検知するのが目的
+      - name: Smoke test (公開ページの疎通確認)
+        run: |
+          URL="${{ steps.deployment.outputs.page_url }}"
+          echo "checking ${URL}"
+          for i in $(seq 1 10); do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' "${URL}main.dart.js" || echo 000)
+            if [ "$code" = "200" ]; then
+              echo "OK: main.dart.js を配信できています (attempt ${i})"
+              exit 0
+            fi
+            echo "attempt ${i}: HTTP ${code} — 反映待ち"
+            sleep 15
+          done
+          echo "::error::デプロイ後に ${URL}main.dart.js を取得できませんでした"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,8 @@ jobs:
             echo "- [ ] 破壊的スキーマ変更を含む場合のみ: \`mise run config-set-prod minSupportedBuildNumber ${BUILD_NUMBER}\`"
             echo
             echo "問題が起きた場合のロールバック: \`mise run rollback-web <前のタグ>\`"
-            echo "（手順の詳細は [docs/release.md](../blob/main/docs/release.md)）"
+            # Release ページ (/releases/tag/...) を基準に相対解決されるため絶対 URL で書く
+            echo "（手順の詳細は [docs/release.md](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/main/docs/release.md)）"
             echo
             echo "---"
             echo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release
+
+# `v*` タグの push で GitHub Release を作る。
+# タグは scripts/release.sh (`mise run release`) が打ち、main への push で
+# main.yml が本番デプロイを行う。この workflow はデプロイそのものはせず、
+# 「何をリリースしたか」と「リリース後に手で実施すべきこと」を記録するのが役割。
+on:
+  push:
+    tags: [ "v*" ]
+
+permissions:
+  contents: write
+
+jobs:
+  github_release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # 直前のタグとの差分を取るため全履歴・全タグを取得する
+          fetch-depth: 0
+
+      - name: 直前のタグと差分の種類を判定
+        id: diff
+        run: |
+          set -uo pipefail
+
+          # 自分自身を除いた最新のタグ。初回リリースでは空になる
+          PREV_TAG=$(git tag --sort=-creatordate | grep -vFx "${GITHUB_REF_NAME}" | head -n 1 || true)
+          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${PREV_TAG}" ]; then
+            CHANGED=$(git diff --name-only "${PREV_TAG}" "${GITHUB_REF_NAME}")
+          else
+            # 初回リリース: 比較対象がないので全ファイルを「変更あり」として扱う
+            CHANGED=$(git ls-tree -r --name-only "${GITHUB_REF_NAME}")
+          fi
+
+          if echo "${CHANGED}" | grep -qxF 'firestore.rules'; then
+            echo "rules_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rules_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          BUILD_NUMBER=$(git show "${GITHUB_REF_NAME}:pubspec.yaml" | sed -nE 's/^version:[[:space:]]*[^+]*\+([0-9]+).*/\1/p')
+          echo "build_number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: リリースノートを作成
+        id: notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREV_TAG: ${{ steps.diff.outputs.prev_tag }}
+          RULES_CHANGED: ${{ steps.diff.outputs.rules_changed }}
+          BUILD_NUMBER: ${{ steps.diff.outputs.build_number }}
+        run: |
+          set -euo pipefail
+
+          # GitHub の自動生成リリースノート (コミット / PR 一覧)
+          if [ -n "${PREV_TAG}" ]; then
+            GENERATED=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="${GITHUB_REF_NAME}" \
+              -f previous_tag_name="${PREV_TAG}" --jq .body)
+          else
+            GENERATED=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="${GITHUB_REF_NAME}" --jq .body)
+          fi
+
+          {
+            echo "## リリース後の手動チェック"
+            echo
+            echo "- [ ] 本番 URL (https://firstforest.github.io/my_manga_editor/) で動作確認"
+            if [ "${RULES_CHANGED}" = "true" ]; then
+              echo "- [ ] **\`firestore.rules\` に変更あり** → \`mise run deploy-rules-prod\` を実行する"
+              echo "  （ルールのデプロイは Web デプロイと連動していない）"
+            fi
+            echo "- [ ] 破壊的スキーマ変更を含む場合のみ: \`mise run config-set-prod minSupportedBuildNumber ${BUILD_NUMBER}\`"
+            echo
+            echo "問題が起きた場合のロールバック: \`mise run rollback-web <前のタグ>\`"
+            echo "（手順の詳細は [docs/release.md](../blob/main/docs/release.md)）"
+            echo
+            echo "---"
+            echo
+            echo "${GENERATED}"
+          } > release_notes.md
+
+          cat release_notes.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file release_notes.md \
+            --verify-tag

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,6 +11,14 @@
 | Firestore データ | アプリが書き込む | バックアップから復元 (`mise run restore-prod`) |
 | `config/app` 設定 | `mise run config-set-prod` | 同コマンドで前の値に戻す |
 
+GitHub Actions は 3 つに分かれている ([.claude/rules/ci.md](../.claude/rules/ci.md) 参照)。
+
+| workflow | いつ動くか | 役割 |
+|---|---|---|
+| `ci.yml` | PR / `develop` への push | analyze・test・Web ビルドの確認。**リリース前の品質ゲート** |
+| `main.yml` | `main` への push | 本番ビルド → GitHub Pages デプロイ → 公開ページの疎通確認 |
+| `release.yml` | `v*` タグの push | GitHub Release の作成（リリース後の手動作業チェックリスト付き） |
+
 - 作業ブランチは `develop`、リリースブランチは `main`。`main` に push されると
   [.github/workflows/main.yml](../.github/workflows/main.yml) が `--dart-define=ENV=prod` で
   Flutter Web をビルドし GitHub Pages (https://firstforest.github.io/my_manga_editor/) へデプロイする
@@ -34,6 +42,7 @@ mise run release --dry-run    # 何が起こるかの確認だけ
    `origin/main` のコミットがすべて `develop` に取り込み済み
 2. **確認** — リリース内容 (`origin/main..develop` のコミット一覧) と新バージョンを表示して y/N
 3. **品質ゲート** — `flutter analyze` && `flutter test`
+   (ルートと `local_package/my_manga_editor_data` の両方。`mise run check` と同内容)
 4. **prod バックアップ** — `scripts/firestore_backup.mjs prod` で Firestore 全データを
    `backups/prod-<日時>/` にダンプ (git 管理外)。ロールバック時の保険
 5. **バージョン更新** — `pubspec.yaml` を書き換えて `chore(release): v...` をコミット
@@ -47,6 +56,11 @@ gh run watch          # デプロイの進行状況を追う
 
 ### リリース前チェックリスト
 
+- [ ] `develop` の CI (`ci.yml`) が緑か (`gh run list --branch develop --limit 1`)
+- [ ] **ロールバック先のタグが存在するか** (`git tag -l 'v*'`)。
+      タグが 1 つも無い状態では `mise run rollback-web` が使えないため、
+      最初のリリース前に現在の `main` にタグを打っておく:
+      `git tag v1.0.0+1 origin/main && git push origin v1.0.0+1`
 - [ ] `develop` で動作確認済みか (`mise run run` は dev Firebase に接続する)
 - [ ] スキーマ変更を含む場合、[.claude/rules/data-layer.md](../.claude/rules/data-layer.md) の
       expand-contract ルールに従っているか (旧フィールドの削除は次リリース以降)

--- a/docs/release.md
+++ b/docs/release.md
@@ -61,6 +61,8 @@ gh run watch          # デプロイの進行状況を追う
       タグが 1 つも無い状態では `mise run rollback-web` が使えないため、
       最初のリリース前に現在の `main` にタグを打っておく:
       `git tag v1.0.0+1 origin/main && git push origin v1.0.0+1`
+- [ ] **タグからのデプロイが許可されているか**（下記「ロールバック」の事前設定）。
+      未設定だとロールバックが environment 保護で止まる
 - [ ] `develop` で動作確認済みか (`mise run run` は dev Firebase に接続する)
 - [ ] スキーマ変更を含む場合、[.claude/rules/data-layer.md](../.claude/rules/data-layer.md) の
       expand-contract ルールに従っているか (旧フィールドの削除は次リリース以降)
@@ -115,6 +117,23 @@ gh run watch                           # デプロイ完了を待つ
 
 仕組み: GitHub Actions の `workflow_dispatch` をタグ ref で起動し、そのタグの時点のコードを
 ビルド・デプロイする。
+
+> **事前設定 (1 回だけ必要)**
+>
+> GitHub Pages の `github-pages` environment には deployment branch policy があり、
+> 初期状態では **`main` ブランチからのデプロイしか許可されていない**。
+> このままタグ ref で起動するとデプロイのジョブが environment 保護で止まり、
+> ロールバックが機能しない。タグを許可するポリシーを追加しておくこと:
+>
+> ```bash
+> # 現在の許可対象を確認
+> gh api repos/firstforest/my_manga_editor/environments/github-pages/deployment-branch-policies
+>
+> # v* タグからのデプロイを許可する
+> gh api --method POST \
+>   repos/firstforest/my_manga_editor/environments/github-pages/deployment-branch-policies \
+>   -f name='v*' -f type='tag'
+> ```
 
 注意点:
 

--- a/lib/feature/manga/view/workspace.dart
+++ b/lib/feature/manga/view/workspace.dart
@@ -120,8 +120,13 @@ class _QuillEditor extends HookConsumerWidget {
             showQuote: false,
             showIndent: false,
             showLink: false,
+            // flutter_quill 側で experimental 指定の API。非表示にする用途で
+            // 意図的に使っている (警告のままだと flutter analyze が exit 1 になる)
+            // ignore: experimental_member_use
             showClipboardCut: false,
+            // ignore: experimental_member_use
             showClipboardCopy: false,
+            // ignore: experimental_member_use
             showClipboardPaste: false,
             showRedo: false,
             showUndo: false,

--- a/mise.toml
+++ b/mise.toml
@@ -61,13 +61,24 @@ run = "node scripts/config.mjs dev set"
 [tasks.config-set-prod]
 run = "node scripts/config.mjs prod set"
 
-# 静的解析
+# 静的解析（ルートパッケージのみ）
 [tasks.analyze]
 run = "flutter analyze"
 
-# テスト
+# テスト（ルートパッケージのみ）
 [tasks.test]
 run = "flutter test"
+
+# CI (.github/workflows/ci.yml) と同じ品質ゲートをローカルで流す。
+# analyze / test はカレントパッケージしか見ないため、データ層は個別に実行する
+[tasks.check]
+run = [
+  "flutter analyze",
+  "cd local_package/my_manga_editor_data && flutter analyze",
+  "flutter test",
+  "cd local_package/my_manga_editor_data && flutter test",
+]
+
 # --- リリース運用 (詳細: docs/release.md) -----------------------------------
 
 # 本番リリース (scripts/release.sh)。引数: patch(デフォルト)|minor|major, --dry-run 等

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,7 +7,7 @@
 # やること (この順):
 #   1. 前提チェック: develop ブランチ / クリーンな作業ツリー / origin と同期済み
 #   2. リリース内容 (origin/main..develop) と新バージョンを表示して確認プロンプト
-#   3. flutter analyze && flutter test
+#   3. flutter analyze && flutter test (ルート + local_package/my_manga_editor_data)
 #   4. prod Firestore のバックアップ (scripts/firestore_backup.mjs → backups/)
 #   5. pubspec.yaml のバージョンを更新してコミット (ビルド番号は必ず +1)
 #   6. タグ付け → main へマージ → push (main への push で GitHub Pages に自動デプロイ)
@@ -106,10 +106,14 @@ esac
 if $SKIP_CHECKS; then
   echo "(--skip-checks: analyze / test を飛ばします)"
 else
+  # analyze / test はカレントパッケージのみが対象なので、データ層パッケージも個別に流す
+  # (CI の .github/workflows/ci.yml と同じ内容)
   step "flutter analyze"
   flutter analyze
+  (cd local_package/my_manga_editor_data && flutter analyze)
   step "flutter test"
   flutter test
+  (cd local_package/my_manga_editor_data && flutter test)
 fi
 
 # --- 4. prod Firestore バックアップ ------------------------------------------


### PR DESCRIPTION
develop を main にリリースする前の確認と、リリース周りの GitHub Actions 整備です。

## 🔴 これが無いとリリースできなかった点（このPRで修正）

`flutter analyze` が **exit 1** を返す状態でした（flutter_quill の experimental API による warning 3 件）。
`scripts/release.sh` は `set -e` で品質ゲートを回すため、**`mise run release` は必ず品質ゲートで停止します**。
行単位の `// ignore: experimental_member_use` で解消しました。

## 🟠 品質ゲートの取りこぼし（このPRで修正）

`flutter analyze` / `flutter test` はカレントパッケージしか対象にしません。
`local_package/my_manga_editor_data` のテスト 6 件は **リリース前に一度も実行されていませんでした**。
`release.sh` / `ci.yml` / `mise run check` のすべてで両パッケージを対象にしています。

## 追加・変更した workflow

| workflow | トリガー | 役割 |
|---|---|---|
| `ci.yml` (新規) | PR / `develop` push | 両パッケージの analyze・test + デプロイと同条件の Web ビルド |
| `release.yml` (新規) | `v*` タグ push | GitHub Release 作成。`firestore.rules` の変更を検知して手動デプロイをチェックリスト化 |
| `main.yml` (更新) | `main` push / 手動 | checkout v4、Pages デプロイの直列化、デプロイ後の疎通確認を追加 |

`mise-action` には `install_args: flutter` を指定しています。`mise.toml` の `ruby = "latest"` は
CI では不要で、指定しないとソースビルドで時間を浪費するためです。
このPRでの CI 実行は **両ジョブ success（3分16秒 / 2分07秒）** でした。

## リリース対象の実データ確認（prod バックアップ 1,324 ドキュメント）

- **稼働中のサービスです**。ユーザー 35 人、直近 7 日 1 人 / 30 日 4 人 / 90 日 11 人が活動。
  最新更新は 2026-08-01。作品 73・ページ 293・Delta 956
- **全 293 ページが v1 形式**（`schemaVersion` / `sceneUnits` なし）。リリース後は全ページが
  lazy migration の対象になります（移行コードはテスト済み）
- **画像・動画の embed は 1 件も存在しませんでした**。`embedBuilders` 削除により
  `UnimplementedError` でページが開けなくなる懸念はありません

## リリース前に残っている手動作業

- [ ] **ロールバック先タグの作成**（タグが 0 件のため現状ロールバック不能）
      `git tag v1.0.0+1 origin/main && git push origin v1.0.0+1`
- [ ] **タグからのデプロイを許可**。`github-pages` environment の deployment branch policy が
      `main` ブランチのみで、このままでは `mise run rollback-web` が environment 保護で止まります
      ```bash
      gh api --method POST \
        repos/firstforest/my_manga_editor/environments/github-pages/deployment-branch-policies \
        -f name='v*' -f type='tag'
      ```
- [x] ~~`mise run deploy-rules-prod`~~ 実施済み。旧ルールとの差分を精査し、アプリが触る 4 パス
      （`users/{uid}` / `mangas` / `pages` / `deltas`）はいずれも新旧で結果が同じであることを確認しました。
      旧ルールの `allow create` バリデーションは現行スキーマとフィールド名が食い違っており
      （`startPage` vs `startPageDirection` 等）常に false で、実効性はありませんでした。
      変わったのは `config/app` が読めるようになった点だけで、バージョンゲートが初めて機能します
      （`minSupportedBuildNumber` は 0 のため誰も締め出されません）

## その他の確認済み事項

- **Firebase 接続先は変わりません**。main には `env_config.dart` が無く常に prod 設定を使っており、
  デプロイ済み `main.dart.js` も prod (`my-manga-editor`) を参照していることを実物で確認しました
- スキーマ移行（v1 → v2 の lazy migration）とロールバック互換はテスト済み。
  ただしロールバック時、リリース後に新規作成されたページは旧クライアントでは空ページに見えます
- 旧 URL `/` は `/manga` へ転送されます（develop の #11 で対応済み）
- 本番と同条件の Web ビルド（`--dart-define=ENV=prod`）成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
